### PR TITLE
Remove automatic period placement in \paragraph headers

### DIFF
--- a/Sample_paper/sig-alternate.cls
+++ b/Sample_paper/sig-alternate.cls
@@ -1171,7 +1171,6 @@
                 \hskip -\parindent
                 \begingroup
                     \@svsechd
-                    \@period
                 \endgroup
                 \unskip
                 \@tempskipa #1\relax


### PR DESCRIPTION
This removes the automatic addition of a period at the end of paragraph headers when using the \paragraph function.