### PR TITLE
Add 3 things to fix warnings

### DIFF
--- a/Sample_paper/sample_paper.tex
+++ b/Sample_paper/sample_paper.tex
@@ -24,6 +24,7 @@
 %% The first command in your LaTeX source must be the \documentclass command.
 \documentclass[sigplan,screen,nonacm]{acmart}
 \usepackage{color}
+\setlength {\marginparwidth }{2cm}
 \usepackage[colorinlistoftodos]{todonotes}
 \usepackage[
     type={CC},
@@ -155,7 +156,7 @@ the context of an ``actual'' document, the \LaTeX\ commands
 specifically available for denoting the structure of a
 proceedings paper, rather than with giving rigorous descriptions
 or explanations of such commands. Section~\ref{sec:body} introduces the main
-examples of formatting, and Section~\ref{sec:conclusions} wraps things up. 
+examples of formatting, and Section~\ref{sec:bibliography} explains the basics of using BibTeX to handle citations. 
 
 \section{The {\it Body} of The Paper}
 \label{sec:body}
@@ -497,6 +498,7 @@ You shouldn't use any other forms here.
 
 
 \section{Citations and Bibliographies}
+\label{sec:bibliography}
 
 The use of BibTeX for the preparation and formatting of one's
 references is strongly recommended. Authors' names should be complete


### PR DESCRIPTION
1. \setlength {\marginparwidth }{2cm}, without it you get the error "Package todonotes Warning: The length marginparwidth is less than 2cm and will most likely cause issues with the appearance of inserted todonotes. The issue can be solved by adding a line like \setlength {\marginparwidth }{2cm} prior to loading the todonotes package. on input line 55."
2. the label for section "citation and bibliography"
3. changed the ref to conclusion to be a referance to bibliography, because conclusion does not exist

There are still warnings "
Overfull \hbox (5.99104pt too wide) in paragraph at lines 222--226 Overfull \hbox (18.46985pt too wide) in paragraph at lines 510--512 Underfull \vbox (badness 1142) has occurred while \output is active [] Underfull \vbox (badness 10000) has occurred while \output is active [] "
But I do not know how to fix that, and it is not harming the students, as they will delete the offending lines anyways.